### PR TITLE
Add filename for applet window button

### DIFF
--- a/org.kde.pix.json
+++ b/org.kde.pix.json
@@ -154,6 +154,7 @@
                     "type": "archive",
                     "url": "https://github.com/psifidotos/applet-window-buttons/archive/refs/tags/0.9.0.tar.gz",
                     "sha256": "053201441e2cc7c0589c920028b985752ad9a87dc0f7fb35070cf44c9fcfbab7",
+                    "dest-filename": "applet-window-buttons.tar.gz",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/psifidotos/applet-window-buttons/releases/latest",


### PR DESCRIPTION
Applet window buttons need filename extension, otherwise it doesn't extract and build fails.